### PR TITLE
Fix GH-actions (Rcmdcheck)

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -29,6 +29,7 @@ jobs:
           - {os: windows-latest, r: 'release'}
 
     env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       RSPM: ${{ matrix.config.rspm }}
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,10 +25,7 @@ Imports:
 Suggests: 
     covr,
     knitr,
-    kwb.nextcloud,
     rmarkdown
-Remotes:
-    github::kwb-r/kwb.nextcloud
 VignetteBuilder: 
     knitr
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,8 @@ Imports:
 Suggests: 
     covr,
     knitr,
-    rmarkdown
+    rmarkdown,
+    testthat
 VignetteBuilder: 
     knitr
 Encoding: UTF-8


### PR DESCRIPTION
currently failing while installing  R package kwb.nextcloud, e.g.:
https://github.com/KWB-R/kwb.infoworks/runs/4021012897?check_suite_focus=true#step:5:23

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kwb-r/kwb.infoworks/2)
<!-- Reviewable:end -->
